### PR TITLE
smaller navbar and remove spacing

### DIFF
--- a/src/qml/ApplicationContent.qml
+++ b/src/qml/ApplicationContent.qml
@@ -124,7 +124,7 @@ Item {
       right: parent.right
       bottom: parent.bottom
     }
-    height: 69
+    height: 50
     NavigationHome {
       anchors.fill: parent
     }

--- a/src/qml/ApplicationContent.qml
+++ b/src/qml/ApplicationContent.qml
@@ -124,7 +124,7 @@ Item {
       right: parent.right
       bottom: parent.bottom
     }
-    height: 100
+    height: 69
     NavigationHome {
       anchors.fill: parent
     }

--- a/src/qml/NavigationHome.qml
+++ b/src/qml/NavigationHome.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.15
 
 Item {
   RowLayout {
+    spacing: 0
     anchors {
       fill: parent
       margins: 4


### PR DESCRIPTION
changed navbar height to 69
and remove spacing to make it look like a bar instead of separate buttons

![image](https://user-images.githubusercontent.com/30526233/135478816-3dc3306f-2bf6-45ca-bc21-7b538a600ddb.png)
