### PR TITLE
update  `LibraryBase` to be more consistent

### DIFF
--- a/src/qml/LibraryBase.qml
+++ b/src/qml/LibraryBase.qml
@@ -57,7 +57,7 @@ Rectangle {
           fill: parent
           margins: 4
         }
-        fillMode: Image.PreserveAspectFit
+        fillMode: Image.PreserveAspectCrop
         source: thumbnailUrl
 
         OpacityMask {
@@ -69,23 +69,24 @@ Rectangle {
           id: mask
           anchors.fill: image
           gradient: Gradient {
-              GradientStop { position: 0.6;  color: "transparent"}
-              GradientStop { position: 0.95; color: "black" }
+              GradientStop { position: 0.5;  color: "transparent"}
+              GradientStop { position: 0.99; color: "black" }
           }
         }
 
         Text {
           id: infoText
           anchors {
-            margins: 4
+            margins: 5
             bottom: image.bottom
             left: image.left
             right: image.right
           }
           color: "white"
-          font.bold: true
-          font.pixelSize: 16
+          font.pixelSize: parent.width/8
+          font.weight: Font.DemiBold
           wrapMode: Text.WordWrap
+          maximumLineCount: 3
           text: title
           style: Text.Outline
           styleColor: "black"


### PR DESCRIPTION
minor changes: 

added `MaximumLineCount` to prevent extra long title overflow
used `parent.width/8` to set the font size to make it responsive
changed to `Image.PreserveAspectCrop` instead of `Image.PreserveAspectFit` to prevent some image going smaller than their cells
some small margin and gradient changes

![iJon5a3XTK](https://user-images.githubusercontent.com/30526233/135669434-2c2d7475-bf20-4576-88b2-2bde9d7804e0.gif)
